### PR TITLE
Show progress for HTTP requests

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -18,6 +18,14 @@
   version = "v1.3.1"
 
 [[projects]]
+  digest = "1:92af3af7106897c682e665f62136f343708e293e62792578a5753af0473c7975"
+  name = "github.com/cavaliercoder/grab"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "2c8601de6d9ac140430fd4c9de28509a0b855af5"
+  version = "v2.0.0"
+
+[[projects]]
   digest = "1:b498b36dbb2b306d1c5205ee5236c9e60352be8f9eea9bf08186723a9f75b4f3"
   name = "github.com/emirpasic/gods"
   packages = [
@@ -330,6 +338,7 @@
   analyzer-name = "dep"
   analyzer-version = 1
   input-imports = [
+    "github.com/cavaliercoder/grab",
     "github.com/spf13/cobra",
     "github.com/spf13/pflag",
     "gopkg.in/src-d/go-git.v4",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -26,6 +26,10 @@
 
 
 [[constraint]]
+  name = "github.com/cavaliercoder/grab"
+  version = "2.0.0"
+
+[[constraint]]
   name = "github.com/spf13/cobra"
   version = "0.0.3"
 


### PR DESCRIPTION
Show progress for HTTP requests.

```bash
$ helm import https://kubernetes-charts.storage.googleapis.com/lamp-0.1.5.tgz
Downloading https://kubernetes-charts.storage.googleapis.com/lamp-0.1.5.tgz...
  transferred 0 / 25952 bytes (0.00%)
  transferred 16384 / 25952 bytes (63.13%)
  transferred 16384 / 25952 bytes (63.13%)
  transferred 25952 / 25952 bytes (100.00%)
Download saved to /Users/cw-ozaki/.helm/cache/import/kubernetes-charts.storage.googleapis.com/lamp-0.1.5.tgz 
```
